### PR TITLE
Timeout

### DIFF
--- a/rest/error.go
+++ b/rest/error.go
@@ -39,6 +39,10 @@ const (
 	// request.
 	SendRequestError = "send-request-error"
 
+	// TimeoutError indicates that the request timed out while sending an HTTP
+	// request.
+	TimeoutError = "timeout-error"
+
 	// UnmarshalError indicates that an error occured while deserializing the
 	// body of an HTTP response.
 	UnmarshalError = "unmarshal-error"

--- a/rest/example_test.go
+++ b/rest/example_test.go
@@ -67,6 +67,8 @@ func ExamplePing() {
 	// The endpoint is started like any other http.Server.
 	go rest.ListenAndServe(":12345", nil)
 
+	time.Sleep(10 * time.Millisecond)
+
 	// The rest package also provides a way to query a REST endpoint by
 	// incrementally building a REST request. The body of the query can be set
 	// via the SetBody() function which will serialize the object to JSON using
@@ -114,7 +116,7 @@ func ExamplePing() {
 		SetPath("delay").
 		Send()
 
-	if err := timeoutResp.GetBody(&tick); err == nil {
+	if err := timeoutResp.GetBody(&tick); err.Type != rest.TimeoutError {
 		panic("Whoops! Should time out" + fmt.Sprint(tick))
 	}
 


### PR DESCRIPTION
A TimeoutError type so that we can simply check for timeout errors.
To use this one should set the http.Client.Timeout to the required time.Duration.
